### PR TITLE
Fix bug with incorrect parse exe path with contains space

### DIFF
--- a/Tests/ProcPiperInfoTest.cs
+++ b/Tests/ProcPiperInfoTest.cs
@@ -34,6 +34,7 @@ public class ProcPiperInfoTest
 
     [TestCase(@"EXEC:C:\Foo.exe bar", ExpectedResult = @"C:\Foo.exe")]
     [TestCase(@"EXEC:C:\Foo.exe", ExpectedResult = @"C:\Foo.exe")]
+    [TestCase(@"EXEC:""C:\foo\space dir\bar.exe"" arg1 arg2", ExpectedResult = @"C:\foo\space dir\bar.exe")]
     public string FileNamePatternMatchTest(string input)
     {
         var element = AddressElement.TryParse(input);
@@ -41,6 +42,7 @@ public class ProcPiperInfoTest
     }
 
     [TestCase(@"EXEC:C:\Foo.exe bar1 bar2", ExpectedResult = "bar1 bar2")]
+    [TestCase(@"EXEC:""C:\foo\space dir\bar.exe"" arg1 arg2", ExpectedResult = @"arg1 arg2")]
     public string ArgumentPatternMatchTest(string input)
     {
         var element = AddressElement.TryParse(input);

--- a/winsocat/AddressElement.cs
+++ b/winsocat/AddressElement.cs
@@ -36,7 +36,7 @@ public class AddressElement
             return null!;
 
         string tag = tagSplits[0];
-        string address = tagSplits[1].Substring(0, addressSepOffset);
+        string address = tagSplits[1].Substring(0, addressSepOffset).Trim();
         var options = GetOptions(tagSplits[1].Substring(addressSepOffset));
         
         return new AddressElement(tag, address, options);

--- a/winsocat/Process.cs
+++ b/winsocat/Process.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO.Pipelines;
+using System.CommandLine.Parsing;
 
 namespace Firejox.App.WinSocat;
 
@@ -20,25 +21,14 @@ public class ProcPiperInfo
     public static ProcPiperInfo TryParse(AddressElement element)
     {
         if (!element.Tag.Equals("EXEC", StringComparison.OrdinalIgnoreCase)) return null!;
-        
-        string execPattern = element.Address.Trim('\'', '\"');
-        int sepIndex = execPattern.IndexOf(' ');
-        string filename;
-        string arguments;
-
-        if (sepIndex != -1)
-        {
-            filename = execPattern.Substring(0, sepIndex);
-            arguments = execPattern.Substring(sepIndex + 1);
-        }
-        else
-        {
-            filename = execPattern;
-            arguments = "";
-        }
+        var execPattern = element.Address;
+        var cmdLine = CommandLineStringSplitter.Instance.Split(execPattern);
+        string filename = cmdLine.First();
+        string arguments = String.Join(' ', cmdLine.Skip(1));
 
         return new ProcPiperInfo(filename, arguments);
     }
+
 }
 
 public class ProcPiper : IPiper


### PR DESCRIPTION
Fix #10 
Now it can parse correctly. For example in CMD,
```sh
winsocat EXEC:"\"C:\Program Files\foo\foo.exe\" arg1 arg" stdio
```
It will run `"C:\Program Files\foo\foo.exe" arg1 arg2`.