### PR TITLE
Ability to set permissions to the listening named pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The `address1` can accept `STDIO`, `TCP-LISTEN`, `TCP`, `NPIPE`, `NPIPE-LISTEN`,
 
 The `address2` can accept `STDIO`, `TCP`, `NPIPE`, `EXEC`, `WSL`, `UNIX`, `HVSOCK`, `SP` socket types.
 
+`NPIPE-LISTEN` supports the `ACL=AllowCurrentUser` parameter, in this case, no other user that is connected to the machine can read / write from / to the pipe. The default is `ACL=AllowEveryone`.
+
 ## Examples
 
 * It can bridge standard input/output and tcp connection to address **127.0.0.1** on port **80**.

--- a/Tests/NamedPipeListenPiperInfoTest.cs
+++ b/Tests/NamedPipeListenPiperInfoTest.cs
@@ -5,6 +5,8 @@ namespace APPTest;
 public class NamedPipeListenPiperInfoTest
 {
     [TestCase("NPIPE-LISTEN:fooPipe")]
+    [TestCase("NPIPE-LISTEN:fooPipe,ACL=AllowEveryone")]
+    [TestCase("NPIPE-LISTEN:fooPipe,ACL=AllowCurrentUser")]
     public void VaildInputParseTest(string input)
     {
         var element = AddressElement.TryParse(input);
@@ -18,10 +20,12 @@ public class NamedPipeListenPiperInfoTest
         var element = AddressElement.TryParse(input);
         Assert.NotNull(Firejox.App.WinSocat.NamedPipeListenPiperInfo.TryParse(element));
     }
-    
+
     [TestCase("STDIO")]
     [TestCase("TCP:127.0.0.1:80")]
     [TestCase("TCP-LISTEN:127.0.0.1:80")]
+    [TestCase("NPIPE:fooServer:barPipe")]
+    [TestCase("NPIPE:fooServer:barPipe")]
     [TestCase("NPIPE:fooServer:barPipe")]
     [TestCase(@"EXEC:'C:\Foo.exe bar'")]
     public void InvalidInputParseTest(string input)
@@ -30,10 +34,28 @@ public class NamedPipeListenPiperInfoTest
         Assert.Null(Firejox.App.WinSocat.NamedPipeListenPiperInfo.TryParse(element));
     }
 
-    [TestCase("NPIPE-LISTEN:fooPipe", ExpectedResult = "fooPipe")]
-    public string PipePatternMatchTest(string input)
+    [TestCase("NPIPE-LISTEN:fooPipe")]
+    [TestCase("NPIPE-LISTEN:fooPipe,ACL=AllowEveryone")]
+    [TestCase("NPIPE-LISTEN:fooPipe,ACL=AllowCurrentUser")]
+    public void PipePatternMatchTest(string input)
     {
-        var element = AddressElement.TryParse(input);
-        return Firejox.App.WinSocat.NamedPipeListenPiperInfo.TryParse(element).PipeName;
+        // Case 1 - Default ACL
+        var element = AddressElement.TryParse("NPIPE-LISTEN:fooPipe");
+        var parsed = Firejox.App.WinSocat.NamedPipeListenPiperInfo.TryParse(element);
+        Assert.That(parsed.PipeName, Is.EqualTo("fooPipe"));
+        Assert.That(parsed.ACL, Is.EqualTo("AllowEveryone"));
+
+        // Case 2 - AllowEveryone ACL
+        element = AddressElement.TryParse("NPIPE-LISTEN:fooPipe,ACL=AllowEveryone");
+        parsed = Firejox.App.WinSocat.NamedPipeListenPiperInfo.TryParse(element);
+        Assert.That(parsed.PipeName, Is.EqualTo("fooPipe"));
+        Assert.That(parsed.ACL, Is.EqualTo("AllowEveryone"));
+
+        // Case 3 - AllowCurrentUser ACL
+        element = AddressElement.TryParse("NPIPE-LISTEN:fooPipe,ACL=AllowCurrentUser");
+        parsed = Firejox.App.WinSocat.NamedPipeListenPiperInfo.TryParse(element);
+        Assert.That(parsed.PipeName, Is.EqualTo("fooPipe"));
+        Assert.That(parsed.ACL, Is.EqualTo("AllowCurrentUser"));
+
     }
 }

--- a/Tests/NamedPipeStreamPiperInfoTest.cs
+++ b/Tests/NamedPipeStreamPiperInfoTest.cs
@@ -24,7 +24,7 @@ public class NamedPipeStreamPiperInfoTest
    [TestCase("STDIO")]
    [TestCase("TCP:127.0.0.1:80")]
    [TestCase("TCP-LISTEN:127.0.0.1:80")]
-   [TestCase("NPIPE-LISTEN:fooPipe")] 
+   [TestCase("NPIPE-LISTEN:fooPipe")]
    [TestCase(@"EXEC:'C:\Foo.exe bar'")]
    public void InvalidInputParseTest(string input)
    {


### PR DESCRIPTION
Support for 2 permissions types when using windows named pipes listeners

- `AllowEveryone`
- `AllowCurrentUser`

Examples

- `NPIPE-LISTEN:fooPipe` (`ACL` defaults to `AllowEveryone` to be backwards compatible)
- `NPIPE-LISTEN:fooPipe,ACL=AllowEveryone`
- `NPIPE-LISTEN:fooPipe,ACL=AllowCurrentUser`
